### PR TITLE
Prepare app for AWS Lambda with DynamoDB persistence

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,75 +6,160 @@ import boxing_game_logic as bgl
 
 app = Flask(__name__)
 
-# Simple in-memory store for active game states
-# In a production app, this would be a database or a more robust cache
-active_games = {}
+import os # For environment variables
+import boto3
+from botocore.exceptions import ClientError
 
-def serialize_game_state(game_state: bgl.GameState) -> dict:
-    """
-    Serializes the GameState object (and its nested Fighter objects) into a dictionary
-    that can be easily converted to JSON.
-    """
-    if not game_state:
-        return None
+# Initialize DynamoDB resource.
+# This would typically be done once when the Lambda instance initializes (outside the handler).
+# For local testing, it will also initialize when app.py is run.
+DYNAMODB_TABLE_NAME = os.environ.get('DYNAMODB_TABLE_NAME', 'ARBoxingGameStates') # Get from env var, default for local
+try:
+    # If running on Lambda, region might be set by AWS_REGION env var automatically.
+    # For local testing with DynamoDB Local or a specific AWS region, you might need to specify endpoint_url and region_name.
+    # Example for DynamoDB Local:
+    # dynamodb = boto3.resource('dynamodb', endpoint_url='http://localhost:8000', region_name='us-east-1')
+    # For deployed Lambda, typically just boto3.resource('dynamodb') is enough if region is configured.
+    dynamodb = boto3.resource('dynamodb') # Adjust region if needed for local testing against AWS
+    table = dynamodb.Table(DYNAMODB_TABLE_NAME)
+    # Try a simple operation to check table existence or create it (for local dev)
+    # This is a simplification; table creation should be part of IaC (e.g. SAM template)
+    # table.load() # Check if table exists - this might throw error if it doesn't.
+except Exception as e:
+    app.logger.error(f"Failed to initialize DynamoDB table '{DYNAMODB_TABLE_NAME}': {e}")
+    # Fallback for local testing if DynamoDB isn't set up, to avoid crashing app.py on import.
+    # In a real Lambda, if this fails, the Lambda would likely error out.
+    table = None
+    app.logger.warn("DynamoDB table could not be initialized. Game state will not persist if table is None.")
 
-    def serialize_fighter(fighter: bgl.Fighter) -> dict:
-        if not fighter:
-            return None
-        return {
-            "name": fighter.name.value,
-            "hp": fighter.hp,
-            "max_hp": fighter.max_hp,
-            "stamina": fighter.stamina,
-            "max_stamina": fighter.max_stamina,
-            "knockdowns_this_round": fighter.knockdowns_this_round,
-            "total_knockdowns": fighter.total_knockdowns,
-            "current_action": fighter.current_action.value,
-            "stats": fighter.stats, # Assuming stats dict is already serializable
-            "round_scores": fighter.round_scores
-        }
 
+# Lambda handler function using serverless-wsgi
+# This function will be the entry point for AWS Lambda.
+try:
+    from serverless_wsgi import handle_request as serverless_wsgi_handle_request
+    def lambda_handler(event, context):
+        # Any Lambda-specific initialization or context processing can go here
+        app.logger.info(f"Lambda event: {event}") # Log the event for debugging
+        return serverless_wsgi_handle_request(app, event, context)
+except ImportError:
+    app.logger.warn("serverless-wsgi not found. lambda_handler not defined. App will only run with dev server.")
+    lambda_handler = None
+
+
+# Simple in-memory store for active game states - TO BE REPLACED BY DYNAMODB
+# active_games = {} # Commented out, will use DynamoDB
+
+# The existing serialize_game_state and serialize_fighter are mostly fine.
+# We just need to ensure game_id is part of the GameState object before serialization if it's read from DB.
+# And ensure that any Decimal types from DynamoDB are converted to float/int before bgl logic uses them.
+# The bgl.create_gamestate_from_dict should handle the latter.
+
+def serialize_fighter_for_api(fighter: bgl.Fighter) -> dict:
+    """Ensures fighter data is plain dicts/lists/primitives for JSON, converts enums."""
+    if not fighter: return None
     return {
-        "game_id": game_state.game_id if hasattr(game_state, 'game_id') else None, # Will add this attribute
+        "name": fighter.name.value,
+        "hp": fighter.hp,
+        "max_hp": fighter.max_hp,
+        "stamina": round(fighter.stamina, 1),
+        "max_stamina": fighter.max_stamina,
+        "knockdowns_this_round": fighter.knockdowns_this_round,
+        "total_knockdowns": fighter.total_knockdowns,
+        "current_action": fighter.current_action.value,
+        "stats": {k.value if isinstance(k, bgl.ActionType) else k: v for k, v in fighter.stats.items()},
+        "round_scores": fighter.round_scores
+    }
+
+def serialize_game_state_for_api(game_state: bgl.GameState) -> dict:
+    """Serializes GameState for API responses, ensuring all parts are JSON-friendly."""
+    if not game_state: return None
+    return {
+        "game_id": getattr(game_state, 'game_id', None), # game_id is now part of GameState from bgl
         "match_status": game_state.match_status.value,
         "current_round": game_state.current_round,
         "max_rounds": game_state.max_rounds,
         "round_timer": round(game_state.round_timer, 1),
         "is_round_active": game_state.is_round_active,
-        "between_rounds_timer": round(game_state.between_rounds_timer, 1),
-        "winner": game_state.winner.value if isinstance(game_state.winner, bgl.FighterName) else game_state.winner, # Handles draw string
-        "player": serialize_fighter(game_state.player),
-        "opponent": serialize_fighter(game_state.opponent),
+        "between_rounds_timer": round(getattr(game_state, 'between_rounds_timer', 0), 1),
+        "winner": game_state.winner.value if isinstance(game_state.winner, bgl.FighterName) else game_state.winner,
+        "player": serialize_fighter_for_api(game_state.player),
+        "opponent": serialize_fighter_for_api(game_state.opponent),
         "knockdown_info": {
             "is_knockdown": game_state.knockdown_info["is_knockdown"],
             "fighter_down": game_state.knockdown_info["fighter_down"].value if game_state.knockdown_info["fighter_down"] else None,
             "count": round(game_state.knockdown_info["count"], 1)
         },
-        "event_log": game_state.event_log[-10:] # Send last 10 events
+        "event_log": game_state.event_log[-10:]
     }
 
+
 @app.route('/game/start', methods=['POST'])
-def start_game():
+def start_game_api(): # Renamed to avoid conflict if old start_game exists
     game_id = str(uuid.uuid4())
     game_state = bgl.initialize_new_game()
-    game_state.game_id = game_id # Add game_id to the game_state object itself
+    game_state.game_id = game_id # Assign game_id to the GameState object
 
-    # Start the first round immediately for simplicity in this API
     bgl.start_new_round(game_state)
 
-    active_games[game_id] = game_state
+    if table:
+        try:
+            # Use the API serializer which handles enums correctly for storage
+            item_to_store = serialize_game_state_for_api(game_state)
+            # DynamoDB expects all top-level keys for the item, game_id is already in item_to_store
+            table.put_item(Item=item_to_store)
+            app.logger.info(f"Game started and saved to DynamoDB with ID: {game_id}")
+        except ClientError as e:
+            app.logger.error(f"DynamoDB ClientError saving game: {e.response['Error']['Message']}")
+            return jsonify({"error": "Failed to save initial game state"}), 500
+        except Exception as e: # Catch any other unexpected errors
+            app.logger.error(f"Unexpected error saving game to DynamoDB: {str(e)}")
+            return jsonify({"error": "Unexpected server error during game start"}), 500
+    else:
+        app.logger.error("DynamoDB table not configured. Cannot save game.")
+        return jsonify({"error": "Database service not available"}), 503
 
-    app.logger.info(f"Game started with ID: {game_id}")
-    return jsonify(serialize_game_state(game_state)), 200
+    return jsonify(serialize_game_state_for_api(game_state)), 200
+
 
 @app.route('/game/<game_id>/action', methods=['POST'])
-def player_action(game_id):
-    game_state = active_games.get(game_id)
+def player_action_api(game_id): # Renamed
+    game_state_dict = None
+    if table:
+        try:
+            response = table.get_item(Key={'game_id': game_id})
+            if 'Item' not in response:
+                app.logger.warn(f"Game not found in DynamoDB: {game_id}")
+                return jsonify({"error": "Game not found"}), 404
+            game_state_dict = response['Item']
+        except ClientError as e:
+            app.logger.error(f"DynamoDB ClientError fetching game {game_id}: {e.response['Error']['Message']}")
+            return jsonify({"error": "Failed to retrieve game state"}), 500
+        except Exception as e:
+            app.logger.error(f"Unexpected error fetching game {game_id} from DynamoDB: {str(e)}")
+            return jsonify({"error": "Unexpected error retrieving game state"}), 500
+
+    else:
+        app.logger.error("DynamoDB table not configured. Cannot process action.")
+        return jsonify({"error": "Database service not available"}), 503
+
+    # Deserialize the dictionary from DynamoDB back into our GameState object
+    # This now uses the new helper in bgl
+    game_state = bgl.create_gamestate_from_dict(game_state_dict)
     if not game_state:
-        return jsonify({"error": "Game not found"}), 404
+        app.logger.error(f"Failed to deserialize game state for {game_id} from dict: {game_state_dict}")
+        return jsonify({"error": "Failed to process game state data"}), 500
+
+    # Ensure last_tick_time is set correctly after deserialization, as it's critical for game_tick
+    if not hasattr(game_state, 'last_tick_time') or game_state.last_tick_time == 0:
+        # If last_tick_time wasn't stored or was invalid, set it to now to avoid large delta_time issues.
+        # However, for consistency, it's better if it's always stored and retrieved.
+        # The create_gamestate_from_dict defaults it to time.time() if not found.
+        pass
+
 
     if game_state.match_status == bgl.GameStatus.MATCH_OVER:
-        return jsonify({"error": "Match is over"}), 400
+        app.logger.info(f"Action request for game {game_id} which is already over.")
+        return jsonify({"error": "Match is over", "game_state": serialize_game_state_for_api(game_state)}), 400
 
     action_data = request.json
     if not action_data or "action" not in action_data:
@@ -86,38 +171,62 @@ def player_action(game_id):
     except KeyError:
         return jsonify({"error": f"Invalid action: {action_str}"}), 400
 
-    # Use the placeholder function which now queues the action
-    # The game_tick will process it.
-    # For API, we assume player actions are primary drivers of ticks for now.
-    if game_state.is_round_active :
+    # Process the action
+    if game_state.is_round_active or game_state.knockdown_info["is_knockdown"] or game_state.match_status == bgl.GameStatus.BETWEEN_ROUNDS:
         bgl.queue_player_action_for_tick(action_type)
-        # Crucially, we need to run a game tick for the action to be processed
-        # and for the AI to potentially react and for timers to update.
-        bgl.game_tick(game_state)
+        bgl.game_tick(game_state) # This updates game_state in place
+
+        # Save the updated game_state back to DynamoDB
+        if table:
+            try:
+                updated_item_to_store = serialize_game_state_for_api(game_state)
+                table.put_item(Item=updated_item_to_store)
+                app.logger.info(f"Action '{action_str}' processed for game {game_id} and state saved. Player HP: {game_state.player.hp}, Opponent HP: {game_state.opponent.hp}")
+            except ClientError as e:
+                app.logger.error(f"DynamoDB ClientError saving updated game state {game_id}: {e.response['Error']['Message']}")
+                # Decide if you should return an error to client or the potentially stale state before save failed
+                return jsonify({"error": "Failed to save updated game state"}), 500
+            except Exception as e:
+                app.logger.error(f"Unexpected error saving updated game state {game_id} to DynamoDB: {str(e)}")
+                return jsonify({"error": "Unexpected server error saving game state"}), 500
+        else:
+            # This case should ideally not be reached if initial checks for table are done.
+            app.logger.error("DynamoDB table not configured. Cannot save updated game state.")
+            return jsonify({"error": "Database service not available during action processing"}), 503
     else:
-        app.logger.warn(f"Action {action_str} received for game {game_id} but round is not active.")
-        # Optionally, still run a game_tick if, for example, it's between rounds to advance that timer
-        bgl.game_tick(game_state)
+        app.logger.warn(f"Action '{action_str}' received for game {game_id} but game not in a state to process actions directly. Status: {game_state.match_status.value}")
+        # Return current (un-ticked) state if no tick was processed
 
+    return jsonify(serialize_game_state_for_api(game_state)), 200
 
-    app.logger.info(f"Action '{action_str}' received for game {game_id}")
-    return jsonify(serialize_game_state(game_state)), 200
 
 @app.route('/game/<game_id>/state', methods=['GET'])
-def get_game_state(game_id):
-    game_state = active_games.get(game_id)
-    if not game_state:
-        return jsonify({"error": "Game not found"}), 404
+def get_game_state_api(game_id): # Renamed
+    # game_state = active_games.get(game_id) # Old in-memory
+    if table:
+        try:
+            response = table.get_item(Key={'game_id': game_id})
+            if 'Item' in response:
+                game_state_dict = response['Item']
+                game_state = bgl.create_gamestate_from_dict(game_state_dict) # Deserialize
+                if not game_state:
+                     app.logger.error(f"Failed to deserialize game state for GET {game_id}")
+                     return jsonify({"error": "Failed to process game state data"}), 500
+                app.logger.info(f"State requested and retrieved from DynamoDB for game {game_id}")
+                return jsonify(serialize_game_state_for_api(game_state)), 200
+            else:
+                app.logger.warn(f"Game not found in DynamoDB on GET request: {game_id}")
+                return jsonify({"error": "Game not found"}), 404
+        except ClientError as e:
+            app.logger.error(f"DynamoDB ClientError fetching game state {game_id} on GET: {e.response['Error']['Message']}")
+            return jsonify({"error": "Failed to retrieve game state"}), 500
+        except Exception as e:
+            app.logger.error(f"Unexpected error fetching game state {game_id} on GET from DynamoDB: {str(e)}")
+            return jsonify({"error": "Unexpected error retrieving game state"}), 500
+    else:
+        app.logger.error("DynamoDB table not configured. Cannot get game state.")
+        return jsonify({"error": "Database service not available"}), 503
 
-    # Optionally, run a game_tick if state is requested to ensure it's fresh,
-    # especially if AI can act or timers need to advance independently of player actions.
-    # This makes GET /state have a side effect, which is not always ideal REST practice,
-    # but common in simple game servers.
-    # if game_state.is_round_active or game_state.knockdown_info["is_knockdown"] or game_state.match_status == bgl.GameStatus.BETWEEN_ROUNDS:
-    #    bgl.game_tick(game_state)
-
-    app.logger.info(f"State requested for game {game_id}")
-    return jsonify(serialize_game_state(game_state)), 200
 
 if __name__ == '__main__':
     # The following app.run() is for local development only.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 Flask>=3.0.0
 gunicorn>=21.0.0
+boto3>=1.20.0
+serverless-wsgi>=0.3.0

--- a/template.yaml
+++ b/template.yaml
@@ -1,0 +1,90 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: >
+  AR Boxing Game Backend API
+
+Globals:
+  Function:
+    Timeout: 30 # Increased timeout for potential game logic, default is 3s
+    MemorySize: 256 # Increased memory, default is 128MB
+    Runtime: python3.9
+    Architectures:
+      - x86_64 # or arm64 if preferred and dependencies support it
+
+Parameters:
+  DynamoDBTableName:
+    Type: String
+    Default: ARBoxingGameStates
+    Description: Name of the DynamoDB table to store game states.
+
+Resources:
+  ARBoxingGameFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./ # Points to the directory containing app.py, boxing_game_logic.py, and requirements.txt
+      Handler: app.lambda_handler # The path to the lambda handler function in app.py
+      Environment:
+        Variables:
+          DYNAMODB_TABLE_NAME: !Ref DynamoDBTableName
+          # PYTHONUNBUFFERED: "1" # Often useful for seeing logs immediately in CloudWatch
+      Policies:
+        # Policy to allow Lambda to read/write to the specified DynamoDB table
+        - DynamoDBCrudPolicy:
+            TableName: !Ref DynamoDBTableName
+      Events:
+        ApiEvents:
+          Type: HttpApi # Using HTTP API for lower cost and latency (vs REST API)
+          Properties:
+            # Path and method are not strictly needed here if using $default route
+            # but shown for clarity if you wanted more specific routes later.
+            # Path: /{proxy+}
+            # Method: ANY
+            # Using $default route to catch all requests to the API root.
+            # Your Flask routes (/game/start, /game/{game_id}/action, etc.) will be handled by the app.
+            TimeoutInMillis: 29000 # API Gateway timeout, should be less than Lambda timeout
+
+  # Optional: Define the DynamoDB table within the SAM template (Infrastructure as Code)
+  GameStatesDynamoDBTable:
+    Type: AWS::DynamoDB::Table # This is a CloudFormation resource type, not Serverless specific
+    Properties:
+      TableName: !Ref DynamoDBTableName
+      AttributeDefinitions:
+        - AttributeName: game_id
+          AttributeType: S # String
+      KeySchema:
+        - AttributeName: game_id
+          KeyType: HASH # Partition key
+      BillingMode: PAY_PER_REQUEST # Good for unpredictable workloads, can also use PROVISIONED
+      # Optional: Enable Time To Live (TTL) for automatic cleanup of old game states
+      # TimeToLiveSpecification:
+      #   AttributeName: ttl # Name of the attribute that stores the expiration timestamp
+      #   Enabled: true
+
+Outputs:
+  ARBoxingApiEndpoint:
+    Description: "API Gateway endpoint URL for AR Boxing Game"
+    Value: !Sub "https://${ServerlessHttpApi}.execute-api.${AWS::Region}.amazonaws.com/"
+  ARBoxingGameFunctionIamRole:
+    Description: "Implicit IAM Role created for AR Boxing Game function"
+    Value: !GetAtt ARBoxingGameFunctionRole.Arn
+
+```yaml
+# How to deploy using AWS SAM CLI:
+# 1. Install AWS SAM CLI: https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html
+# 2. Configure AWS credentials.
+# 3. Build the application:
+#    sam build
+# 4. Deploy the application:
+#    sam deploy --guided
+#    (This will prompt for parameters like Stack Name, AWS Region, DynamoDBTableName (can use default), and confirmation to deploy changesets)
+#    It will also ask if the function needs permissions to be publicly accessible via API Gateway - say yes.
+# 5. After deployment, the API Gateway endpoint URL will be in the Outputs section.
+#
+# To test locally (simulates Lambda and API Gateway):
+# 1. Ensure Docker is running.
+# 2. Start the local API:
+#    sam local start-api --parameter-overrides DynamoDBTableName=YourLocalOrTestTableName
+#    (You might need to set up DynamoDB Local separately for local testing of persistence,
+#     or point to a dev table in AWS, ensuring your local AWS credentials are set up).
+#    The API will be available at http://localhost:3000 by default.
+```


### PR DESCRIPTION
This commit adapts the Flask backend and adds AWS SAM configuration to enable deployment as a serverless application on AWS Lambda, using DynamoDB for persistent game state storage.

Key changes:

- **`requirements.txt`**:
  - Added `boto3` (AWS SDK for Python) for DynamoDB interaction.
  - Added `serverless-wsgi` to adapt the Flask app for Lambda.

- **`boxing_game_logic.py`**:
  - Introduced `create_fighter_from_dict` and `create_gamestate_from_dict` helper functions. These are crucial for deserializing game state data retrieved from DynamoDB (which is stored as a dictionary) back into the application's Python class instances (`GameState`, `Fighter`), correctly handling enums and nested structures.

- **`app.py` (Flask Backend)**:
  - **DynamoDB Integration**:
    - Initializes a `boto3` DynamoDB resource and table object. The table name is configurable via the `DYNAMODB_TABLE_NAME` environment variable.
    - Replaced the in-memory `active_games` dictionary with DynamoDB operations (`table.put_item`, `table.get_item`) in all API endpoint handlers (`/game/start`, `/game/<game_id>/action`, `/game/<game_id>/state`).
    - Uses the new deserialization functions from `boxing_game_logic.py` to reconstruct game state objects from DynamoDB data.
    - Adapted serialization functions to ensure data is suitable for both JSON API responses and DynamoDB storage.
  - **Lambda Handler**:
    - Added a `lambda_handler(event, context)` function using `serverless_wsgi.handle_request` to make the Flask application callable by AWS Lambda.

- **`template.yaml` (AWS SAM Template)**:
  - Created to define the serverless application stack:
    - **Lambda Function (`ARBoxingGameFunction`)**: Configured with Python 3.9 runtime, handler (`app.lambda_handler`), environment variables (including `DYNAMODB_TABLE_NAME`), and an IAM policy (`DynamoDBCrudPolicy`) granting necessary permissions for the DynamoDB table.
    - **HTTP API Gateway Trigger**: Sets up an API Gateway to invoke the Lambda function via HTTP requests.
    - **DynamoDB Table Definition (`GameStatesDynamoDBTable`)**: Optionally defines the DynamoDB table (`game_id` as HASH key, PAY_PER_REQUEST billing) as part of the SAM stack (Infrastructure as Code).

This set of changes makes the backend stateless by offloading game state to DynamoDB, preparing it for a scalable serverless deployment on AWS Lambda. The actual deployment requires using the AWS SAM CLI.